### PR TITLE
Lock CKEditor Version & Suppress Security Warning

### DIFF
--- a/CKEditor.php
+++ b/CKEditor.php
@@ -22,7 +22,9 @@ class CKEditor extends YiiInputWidget
     /**
      * @var array widget plugin options.
      */
-    public $defaultPluginOptions = [];
+    public $defaultPluginOptions = [
+        'versionCheck' => false
+    ];
 
     /**
      * @var array widget plugin options.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.0",
-        "npm-asset/ckeditor": "^4.8"
+        "npm-asset/ckeditor": "~4.22.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR addresses two updates:

1. **Lock CKEditor Version**: Pins CKEditor to version `4.22.*` to ensure compliance with open-source licensing, as later versions (4.23.0-lts and above) require a license key.
2. **Disable Version Check**: Disables the CKEditor version check to prevent the recurring security warning message:
_“This CKEditor 4.22.1 (Standard) version is not secure. Consider upgrading to the latest one, 4.25.0-lts.”_